### PR TITLE
Add more advanced xml writer.

### DIFF
--- a/src/AdvancedXmlWriter.php
+++ b/src/AdvancedXmlWriter.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Port\Xml;
+
+use Port\Writer;
+use Port\Writer\FlushableWriter;
+
+/**
+ * This writer allows you to write more complex XML from arrays than the default XmlWriter.
+ *
+ * The main differences are that nested arrays can be proceed and XML attributes are supported. 
+ * If the key of an array value starts with '@' the value will be used as a XML attribute.
+ */
+class AdvancedXmlWriter implements Writer, FlushableWriter
+{
+    /**
+     * @var \XmlWriter
+     */
+    protected $xmlWriter;
+
+    /**
+     * @var string
+     */
+    protected $file;
+
+    /**
+     * @var string
+     */
+    protected $rootElement;
+
+    /**
+     * @var array<string, string>
+     */
+    protected $rootElementAttributes;
+
+    /**
+     * @var string
+     */
+    protected $itemElement;
+
+    /**
+     * @var string
+     */
+    protected $version;
+
+    /**
+     * @var string|null
+     */
+    protected $encoding;
+
+    /**
+     * @param string $file
+     */
+    public function __construct(
+        \XmlWriter $xmlWriter,
+        $file,
+        $rootElement = 'items',
+        $rootElementAttributes = [],
+        $itemElement = 'item',
+        $version = '1.0',
+        $encoding = null
+    ) {
+        $this->xmlWriter = $xmlWriter;
+        $this->file = $file;
+        $this->rootElement = $rootElement;
+        $this->rootElementAttributes = $rootElementAttributes;
+        $this->itemElement = $itemElement;
+        $this->version = $version;
+        $this->encoding = $encoding;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepare()
+    {
+        $this->xmlWriter->openUri($this->file);
+        $this->xmlWriter->startDocument($this->version, $this->encoding);
+        $this->xmlWriter->startElement($this->rootElement);
+
+        foreach($this->rootElementAttributes as $key => $value) {
+            $this->xmlWriter->writeAttribute($key, $value);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function writeItem(array $item)
+    {
+        $this->writeXmlItem($item, $this->itemElement);
+    }
+
+    /**
+     * Handle XML write with attributes support.
+     *
+     * @param array $item
+     * @param $elementName
+     */
+    protected function writeXmlItem(array $item, $elementName)
+    {
+        $this->xmlWriter->startElement($elementName);
+
+        $this->writeAttributes($item);
+
+        foreach ($item as $key => $value) {
+            if (substr($key, 0, 1) === '@') {
+                continue;
+            }
+
+            if (is_array($value)) {
+                $this->writeXmlItem($value, $key);
+            } else {
+                $this->xmlWriter->writeElement($key, $value);
+            }
+        }
+
+        $this->xmlWriter->endElement();
+    }
+
+    /**
+     * Write attributes of item.
+     *
+     * @param array $item
+     */
+    protected function writeAttributes(array $item)
+    {
+        foreach ($item as $key => $value) {
+            if (substr($key, 0, 1) !== '@') {
+                continue;
+            }
+
+            $this->xmlWriter->writeAttribute(
+                substr($key, 1),
+                $value
+            );
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function finish()
+    {
+        $this->xmlWriter->endElement();
+        $this->xmlWriter->endDocument();
+        $this->flush();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush()
+    {
+        $this->xmlWriter->flush();
+    }
+
+}


### PR DESCRIPTION
This new xml writer provides 3 more functions which are essential to handle complex xml structures. 

1) It's now possible to provide attributes to the root element. Because this attributes are given as an additional constructor argument, i have created a new class to avoid bc breaks. 

As an alternative, a factory could be used which would call a setter Method. 

2) Nested array can be handled now. 
3) XML attributes can be defined with a traling '@'.

Example: 

```php
$writer = new \Port\Xml\AdvancedXmlWriter(
    new \XMLWriter(), '/tmp/aaa.xml', 'rootElement',
    ['rootAttribute' => 'rootValue']
);

$xml = [
    'key1' => 'value1',
    '@attribute1' => 'attributeValue1',
    'collection' => [
        'foo' => 'bar',
    ],
];
```

```xml
<?xml version="1.0"?>
<rootElement rootAttribute="rootValue">
    <item attribute1="attributeValue1">
        <key1>value1</key1>
        <collection>
            <foo>bar</foo>
        </collection>
    </item>
</rootElement>
```